### PR TITLE
chore(docker): update base image to eclipse-temurin for JRE 25

### DIFF
--- a/configs/docker/Dockerfile
+++ b/configs/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:25-bookworm
+FROM eclipse-temurin:25-jre-jammy
 
 ARG APP_NAME
 ARG UNAME=admin


### PR DESCRIPTION
- Changed Docker base image from openjdk:25-bookworm to eclipse-temurin:25-jre-jammy
- Updated to use Jammy-based JRE image for improved compatibility and support
- Kept build arguments APP_NAME and UNAME unchanged